### PR TITLE
Walk history for files in parallell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +222,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +268,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
@@ -283,6 +340,8 @@ dependencies = [
  "clap_mangen",
  "filetime",
  "git2",
+ "hashbrown",
+ "rayon",
  "vergen",
 ]
 
@@ -800,6 +859,11 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "rayon",
+]
 
 [[package]]
 name = "heck"
@@ -918,6 +982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1086,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1290,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,4 +1577,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ lto = true
 
 [dependencies]
 filetime = "0.2"
+rayon = "1.8"
 
   [dependencies.clap]
   version = "4.4"
@@ -41,6 +42,10 @@ filetime = "0.2"
   [dependencies.git2]
   version = "0.18"
   default-features = false
+
+  [dependencies.hashbrown]
+  version = "0.14"
+  features = [ "rayon" ]
 
 [build-dependencies]
 

--- a/src/bin/git-warp-time.rs
+++ b/src/bin/git-warp-time.rs
@@ -29,6 +29,5 @@ fn main() -> git_warp_time::Result<()> {
         }
         opts = opts.paths(Some(paths));
     }
-    reset_mtime(repo, opts)?;
-    Ok(())
+    reset_mtime(repo, opts)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 
 use filetime::FileTime;
 use git2::Repository;
-use std::collections::HashSet;
+use hashbrown::HashSet;
+use rayon::prelude::*;
 use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::{env, error, fs, result};
@@ -86,7 +87,7 @@ impl Options {
 /// Iterate over either the explicit file list or the working directory files, filter out any that
 /// have local modifications, are ignored by Git, or are in submodules and reset the file metadata
 /// mtime to the commit date of the last commit that affected the file in question.
-pub fn reset_mtime(repo: Repository, opts: Options) -> Result<FileSet> {
+pub fn reset_mtime(repo: Repository, opts: Options) -> Result<()> {
     let workdir_files = gather_workdir_files(&repo)?;
     let touchables: FileSet = match opts.paths {
         Some(ref paths) => {
@@ -106,8 +107,7 @@ pub fn reset_mtime(repo: Repository, opts: Options) -> Result<FileSet> {
             workdir_files.intersection(&candidates).cloned().collect()
         }
     };
-    let touched = touch(&repo, touchables, &opts)?;
-    Ok(touched)
+    process_touchables(touchables, &opts)
 }
 
 /// Return a repository discovered from from the current working directory or $GIT_DIR settings.
@@ -188,74 +188,78 @@ fn gather_workdir_files(repo: &Repository) -> Result<FileSet> {
     Ok(workdir_files)
 }
 
-fn touch(repo: &Repository, touchables: HashSet<String>, opts: &Options) -> Result<FileSet> {
-    let mut touched = FileSet::new();
-    for path in touchables.iter() {
-        let pathbuf = Path::new(path).to_path_buf();
-        let mut revwalk = repo.revwalk().unwrap();
-        // See https://github.com/arkark/git-hist/blob/main/src/app/git.rs
-        revwalk.push_head().unwrap();
-        revwalk.simplify_first_parent().unwrap();
-        let commits: Vec<_> = revwalk
-            .map(|oid| oid.and_then(|oid| repo.find_commit(oid)).unwrap())
-            .collect();
-        let latest_file_oid = commits
-            .first()
-            .unwrap()
-            .tree()
-            .unwrap()
-            .get_path(&pathbuf)
-            .and_then(|entry| {
-                if let Some(git2::ObjectType::Blob) = entry.kind() {
-                    Ok(entry)
-                } else {
-                    Err(git2::Error::new(
-                        git2::ErrorCode::NotFound,
-                        git2::ErrorClass::Tree,
-                        "no blob",
-                    ))
-                }
-            })
-            .unwrap()
-            .id();
-        let mut file_oid = latest_file_oid;
-        let mut file_path = pathbuf;
-        let last_commit = commits
-            .iter()
-            .filter_map(|commit| {
-                let old_tree = commit.parent(0).and_then(|p| p.tree()).ok();
-                let new_tree = commit.tree().ok();
-                let mut diff = repo
-                    .diff_tree_to_tree(old_tree.as_ref(), new_tree.as_ref(), None)
-                    .unwrap();
-                diff.find_similar(Some(git2::DiffFindOptions::new().renames(true)))
-                    .unwrap();
-                let delta = diff.deltas().find(|delta| {
-                    delta.new_file().id() == file_oid
-                        && delta
-                            .new_file()
-                            .path()
-                            .filter(|path| *path == file_path)
-                            .is_some()
-                });
-                if let Some(delta) = delta.as_ref() {
-                    file_oid = delta.old_file().id();
-                    file_path = delta.old_file().path().unwrap().to_path_buf();
-                }
-                delta.map(|_| commit)
-            })
-            .next()
-            .unwrap();
-        let metadata = fs::metadata(path).unwrap();
-        let commit_time = FileTime::from_unix_time(last_commit.time().seconds(), 0);
-        let file_mtime = FileTime::from_last_modification_time(&metadata);
+fn get_timestamps(repo: &Repository, path: &String) -> Result<(FileTime, FileTime)> {
+    let pathbuf = Path::new(&path).to_path_buf();
+    let mut revwalk = repo.revwalk().unwrap();
+    // See https://github.com/arkark/git-hist/blob/main/src/app/git.rs
+    revwalk.push_head().unwrap();
+    revwalk.simplify_first_parent().unwrap();
+    let commits: Vec<_> = revwalk
+        .map(|oid| oid.and_then(|oid| repo.find_commit(oid)).unwrap())
+        .collect();
+    let latest_file_oid = commits
+        .first()
+        .unwrap()
+        .tree()
+        .unwrap()
+        .get_path(&pathbuf)
+        .and_then(|entry| {
+            if let Some(git2::ObjectType::Blob) = entry.kind() {
+                Ok(entry)
+            } else {
+                Err(git2::Error::new(
+                    git2::ErrorCode::NotFound,
+                    git2::ErrorClass::Tree,
+                    "no blob",
+                ))
+            }
+        })
+        .unwrap()
+        .id();
+    let mut file_oid = latest_file_oid;
+    let mut file_path = pathbuf;
+    let last_commit = commits
+        .iter()
+        .filter_map(|commit| {
+            let old_tree = commit.parent(0).and_then(|p| p.tree()).ok();
+            let new_tree = commit.tree().ok();
+            let mut diff = repo
+                .diff_tree_to_tree(old_tree.as_ref(), new_tree.as_ref(), None)
+                .unwrap();
+            diff.find_similar(Some(git2::DiffFindOptions::new().renames(true)))
+                .unwrap();
+            let delta = diff.deltas().find(|delta| {
+                delta.new_file().id() == file_oid
+                    && delta
+                        .new_file()
+                        .path()
+                        .filter(|path| *path == file_path)
+                        .is_some()
+            });
+            if let Some(delta) = delta.as_ref() {
+                file_oid = delta.old_file().id();
+                file_path = delta.old_file().path().unwrap().to_path_buf();
+            }
+            delta.map(|_| commit)
+        })
+        .next()
+        .unwrap();
+    let metadata = fs::metadata(path).unwrap();
+    let commit_time = FileTime::from_unix_time(last_commit.time().seconds(), 0);
+    let file_mtime = FileTime::from_last_modification_time(&metadata);
+    Ok((file_mtime, commit_time))
+}
+
+fn process_touchables(touchables: HashSet<String>, opts: &Options) -> Result<()> {
+    touchables.par_iter().for_each(|path| {
+        let repo = get_repo().unwrap();
+        let (file_mtime, commit_time) = get_timestamps(&repo, path).unwrap();
         if file_mtime != commit_time {
-            filetime::set_file_mtime(path, commit_time)?;
+            filetime::set_file_mtime(path, commit_time).unwrap();
             if opts.verbose {
                 println!("Rewound the clock: {path}");
             }
-            touched.insert((*path).to_string());
         }
-    }
-    Ok(touched)
+    });
+    Ok(())
 }


### PR DESCRIPTION
Closes #9.

This effort is likely fairly futile:

1. It introduces some overhead of having to do git repo initialization stuff multiple times since libgit2 repos don't support sync.
1. The real speed hold up is walking history, not iterating files. This will speed things up by a factor of however many cores a system has (minus some overhead) and make it look super busy, but it won't be enough to be really useful for jumbo-size repositories. It might be **one** order of magnitude faster so I'll probably release it ASAP, but what we really need is **several** orders of magnitude faster.
