### PR TITLE
Enable dynamic completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d11bff0290e9a266fc9b4ce6fa96c2bf2ca3f9724c41c10202ac1daf7a087f8"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "pathdiff",
+ "shlex",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -977,6 +982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1141,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -1335,6 +1355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1642,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1665,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ required-features = ["cli"]
 
 [features]
 default = ["cli", "bash", "elvish", "fish", "manpage", "powershell", "zsh"]
-completions = ["cli", "clap_complete"]
+completions = ["cli", "dep:clap_complete"]
 cli = ["clap"]
 bash = ["completions"]
 elvish = ["completions"]
@@ -40,19 +40,25 @@ snafu = "0.8"
   optional = true
   features = [ "derive", "wrap_help" ]
 
+  [dependencies.clap_complete]
+  version = "4.5"
+  optional = true
+  features = [ "unstable-dynamic" ]
+
   [dependencies.git2]
   version = "0.19"
   default-features = false
 
 [build-dependencies]
 
-  [build-dependencies.clap_complete]
-  version = "4.5"
-  optional = true
-
   [build-dependencies.clap_mangen]
   version = "0.2"
   optional = true
+
+  [build-dependencies.clap_complete]
+  version = "4.5"
+  optional = true
+  features = [ "unstable-dynamic" ]
 
   [build-dependencies.clap]
   version = "4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ snafu = "0.8"
   default-features = false
   features = [ "build", "cargo", "rustc" ]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(build)'] }
+
 [package.metadata.git-cliff.git]
 protect_breaking_commits = true
 commit_parsers = [

--- a/build-aux/build.rs
+++ b/build-aux/build.rs
@@ -11,15 +11,23 @@ use {
 #[cfg(feature = "completions")]
 use {
     clap::CommandFactory,
+    clap_complete::dynamic::ArgValueCompleter,
     clap_complete::generator::generate_to,
     clap_complete::shells::{Bash, Elvish, Fish, PowerShell, Zsh},
     std::{fs, path::Path},
 };
 
 #[cfg(feature = "completions")]
+fn generate_path_completions() -> ArgValueCompleter {
+    ArgValueCompleter::new(|| vec![])
+}
+
+#[cfg(feature = "completions")]
 include!("../src/cli.rs");
 
 fn main() -> Result<()> {
+    println!("cargo:rustc-cfg=build");
+    println!("cargo:rustc-check-cfg=cfg(build)");
     if let Ok(val) = env::var("AUTOTOOLS_DEPENDENCIES") {
         for dependency in val.split(' ') {
             println!("cargo:rerun-if-changed={dependency}");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use clap::Parser;
-use clap_complete::dynamic::{ArgValueCompleter, CompleteCommand, CompletionCandidate};
+use clap_complete::dynamic::CompleteCommand;
+
+#[cfg(all(build, feature = "completions"))]
+use crate::generate_path_completions;
 
 /// CLI utility that resets the timestamps of files in a Git repository working directory
 /// to the exact timestamp of the last commit which modified each file.
@@ -30,16 +33,6 @@ pub struct Cli {
     pub quiet: bool,
 
     /// Optional list of paths to operate on instead of default which is all files tracked by Git
-    #[arg(add = generate_path_completions())]
+    #[cfg_attr(feature = "completions", arg(add = generate_path_completions))]
     pub paths: Option<Vec<String>>,
-}
-
-fn generate_path_completions() -> ArgValueCompleter {
-    ArgValueCompleter::new(|| {
-        vec![
-            CompletionCandidate::new("foo"),
-            CompletionCandidate::new("bar"),
-            CompletionCandidate::new("baz"),
-        ]
-    })
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use clap::Parser;
+use clap_complete::dynamic::{ArgValueCompleter, CompleteCommand, CompletionCandidate};
 
 /// CLI utility that resets the timestamps of files in a Git repository working directory
 /// to the exact timestamp of the last commit which modified each file.
 #[derive(Parser, Debug)]
 #[command(author, bin_name = "git-warp-time")]
 pub struct Cli {
+    /// Used internally by Clap to generate dynamic completions
+    #[command(subcommand)]
+    pub _complete: Option<CompleteCommand>,
+
     /// Include files tracked by Git but modifications in the working tee
     #[arg(short, long)]
     pub dirty: bool,
@@ -25,6 +30,16 @@ pub struct Cli {
     pub quiet: bool,
 
     /// Optional list of paths to operate on instead of default which is all files tracked by Git
-    #[arg(value_hint = clap::ValueHint::FilePath)]
+    #[arg(add = generate_path_completions())]
     pub paths: Option<Vec<String>>,
+}
+
+fn generate_path_completions() -> ArgValueCompleter {
+    ArgValueCompleter::new(|| {
+        vec![
+            CompletionCandidate::new("foo"),
+            CompletionCandidate::new("bar"),
+            CompletionCandidate::new("baz"),
+        ]
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,20 @@ fn gather_workdir_files(repo: &Repository) -> Result<FileSet> {
     Ok(workdir_files)
 }
 
+#[cfg(feature = "completions")]
+pub fn generate_path_completions() -> ArgValueCompleter {
+    let repo = get_repo();
+    let tracked_files = gather_workdir_files(repo);
+    dbg!(tracked_files);
+    ArgValueCompleter::new(|| {
+        vec![
+            CompletionCandidate::new("foo"),
+            CompletionCandidate::new("bar"),
+            CompletionCandidate::new("baz"),
+        ]
+    })
+}
+
 fn diff_affects_oid(diff: &Diff, oid: &Oid, touchable_path: &mut Utf8PathBuf) -> bool {
     diff.deltas().any(|delta| {
         delta.new_file().id() == *oid


### PR DESCRIPTION
The point here is mostly to try out the dynamic completion support before implementing on a more complex project. The goal for this PR would be to replace the file-name completion for `PATH` to only complete files that are tracked by Git and hence eligible for operation.